### PR TITLE
zstandard 0.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zstandard" %}
-{% set version = "0.15.2" %}
+{% set version = "0.18.0" %}
 
 package:
   name: {{ name }}
@@ -11,19 +11,20 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cffi                                   # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python
+    - cffi >=1.11
     - pip
-    - cffi >=1.8
+    - setuptools
+    - wheel
   run:
     - python
-    - cffi >=1.8
+    - cffi >=1.11
 
 test:
   requires:
@@ -36,13 +37,16 @@ test:
 about:
   home: https://github.com/indygreg/python-zstandard
   license: BSD-3-Clause
+  lisense_family: BSD
   license_file: LICENSE
+  license_url: https://github.com/indygreg/python-zstandard/blob/main/LICENSE
   summary: Zstandard bindings for Python
   description: |
     This project provides Python bindings for interfacing with the
     Zstandard compression library. A C extension and CFFI interface are
     provided.
   doc_url: https://github.com/indygreg/python-zstandard/blob/master/README.rst#python-zstandard
+  doc_source_url: https://github.com/indygreg/python-zstandard/tree/main/docs
   dev_url: https://github.com/indygreg/python-zstandard
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 52de08355fd5cfb3ef4533891092bb96229d43c2069703d4aff04fdbedf9c92f
+  sha256: 0ac0357a0d985b4ff31a854744040d7b5754385d1f98f7145c30e02c6865cb6f
 
 build:
   number: 0


### PR DESCRIPTION
Changelog: https://github.com/indygreg/python-zstandard/blob/0.18.0/docs/news.rst
License: https://github.com/indygreg/python-zstandard/blob/main/LICENSE
Requirements: https://github.com/indygreg/python-zstandard/blob/0.18.0/setup.py

Actions:
1. Skip `py<36`
2. Update `cffi` pinning, see https://github.com/indygreg/python-zstandard/blob/20e07de1a9d995766fa24606d5a74bac40b53c6a/setup.py#L25
3. Add `setuptools` & `wheel` to `host`
4. Add `license_family`
5. Add `doc_source_url`