### PR TITLE
additional zstd/LICENSE

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zstandard" %}
-{% set version = "0.18.0" %}
+{% set version = "0.19.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0ac0357a0d985b4ff31a854744040d7b5754385d1f98f7145c30e02c6865cb6f
+  sha256: 31d12fcd942dd8dbf52ca5f6b1bbe287f44e5d551a081a983ff3ea2082867863
 
 build:
   number: 0
@@ -18,7 +18,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cffi >=1.11
+    - cffi 1.15
     - pip
     - setuptools
     - wheel
@@ -41,14 +41,12 @@ about:
   license_file:
     - LICENSE
     - zstd/LICENSE
-  license_url: https://github.com/indygreg/python-zstandard/blob/main/LICENSE
   summary: Zstandard bindings for Python
   description: |
     This project provides Python bindings for interfacing with the
     Zstandard compression library. A C extension and CFFI interface are
     provided.
   doc_url: https://github.com/indygreg/python-zstandard/blob/master/README.rst#python-zstandard
-  doc_source_url: https://github.com/indygreg/python-zstandard/tree/main/docs
   dev_url: https://github.com/indygreg/python-zstandard
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
     This project provides Python bindings for interfacing with the
     Zstandard compression library. A C extension and CFFI interface are
     provided.
-  doc_url: https://github.com/indygreg/python-zstandard/blob/master/README.rst#python-zstandard
+  doc_url: https://github.com/indygreg/python-zstandard/blob/main/README.rst#python-zstandard
   dev_url: https://github.com/indygreg/python-zstandard
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
 about:
   home: https://github.com/indygreg/python-zstandard
   license: BSD-3-Clause
-  lisense_family: BSD
+  license_family: BSD
   license_file:
     - LICENSE
     - zstd/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,9 @@ about:
   home: https://github.com/indygreg/python-zstandard
   license: BSD-3-Clause
   lisense_family: BSD
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - zstd/LICENSE
   license_url: https://github.com/indygreg/python-zstandard/blob/main/LICENSE
   summary: Zstandard bindings for Python
   description: |


### PR DESCRIPTION
Changes:
- License for zstandard in addition to the license for python-zstandard
- Update to 0.19.0

https://github.com/indygreg/python-zstandard/compare/0.18.0...0.19.0