### PR TITLE
zstandard 0.22.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,0 @@
-
-:: Existing egg_info directory causes failure in windows.
-rd /s /q zstandard.egg-info
-
-%PYTHON% setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Otherwise this picks up the wrong linker on Linux (in most cases the system C++ compiler)
-if [ $(uname) == Linux ]; then
-  export LDSHARED="$CC -shared -pthread"
-fi
-python -m pip install --no-deps --ignore-installed .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,15 +9,19 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70
+  patches:
+    - use_system_zstd.patch
 
 build:
   number: 0
   skip: True  # [py<38]
-  script: {{PYTHON}} -m pip install  --global-option="--system-zstd" --no-deps --no-build-isolation . -vv
+  script: {{PYTHON}} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
     - python
     - cffi 1.16

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 31d12fcd942dd8dbf52ca5f6b1bbe287f44e5d551a081a983ff3ea2082867863
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "zstandard" %}
-{% set version = "0.19.0" %}
+{% set version = "0.22.0" %}
+{% set zstd_version = "1.5.5" %}
 
 package:
   name: {{ name }}
@@ -7,24 +8,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 31d12fcd942dd8dbf52ca5f6b1bbe287f44e5d551a081a983ff3ea2082867863
+  sha256: 8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70
 
 build:
-  number: 1
-  skip: True  # [py<36]
+  number: 0
+  skip: True  # [py<38]
+  script: {{PYTHON}} -m pip install  --global-option="--system-zstd" --no-deps --no-build-isolation . -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
     - python
-    - cffi 1.15
+    - cffi 1.16
     - pip
     - setuptools
     - wheel
+    - zstd {{zstd_version}}
   run:
     - python
     - cffi >=1.11
+    # The system zstd library and headers must match what python-zstandard is coded against exactly.
+    # https://github.com/indygreg/python-zstandard/blob/0.22.0/zstd/zstd.h#L110
+    # https://github.com/indygreg/python-zstandard/blob/0.22.0/setup_zstd.py#L38-L40
+    - {{ pin_compatible("zstd", max_pin="x.x.x") }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: {{PYTHON}} -m pip install --no-deps --no-build-isolation . -vv
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   build:
@@ -28,7 +28,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - zstd {{zstd_version}}
+    - zstd {{ zstd_version }}
   run:
     - python
     - cffi >=1.11

--- a/recipe/use_system_zstd.patch
+++ b/recipe/use_system_zstd.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 7cc1f4f..b60468b 100755
+--- a/setup.py
++++ b/setup.py
+@@ -49,7 +49,7 @@ except ImportError:
+ import setup_zstd
+ 
+ SUPPORT_LEGACY = False
+-SYSTEM_ZSTD = False
++SYSTEM_ZSTD = True
+ WARNINGS_AS_ERRORS = False
+ C_BACKEND = True
+ CFFI_BACKEND = True


### PR DESCRIPTION
For PKG-4513 authenticode signing

- Update to 0.22.0
- use system zstd (see comments in recipe).

https://github.com/indygreg/python-zstandard/tree/0.22.0
https://github.com/indygreg/python-zstandard/releases