### PR TITLE
v0.23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,16 +24,16 @@ requirements:
     - m2-patch  # [win]
   host:
     - python
-    - cffi 1.16  # [py<313]
-    - cffi 1.17  # [py>312]
+    - cffi 1.16  # [py<=312]
+    - cffi 1.17  # [py>=313]
     - pip
     - setuptools <69.0.0 
     - wheel
     - zstd {{ zstd_version }}
   run:
     - python
-    - cffi >=1.11  # [py<313]
-    - cffi >=1.17  # [py>312]
+    - cffi >=1.11  # [py<=312]
+    - cffi >=1.17  # [py>=313]
     # The system zstd library and headers must match what python-zstandard is coded against exactly.
     # https://github.com/indygreg/python-zstandard/blob/0.22.0/zstd/zstd.h#L110
     # https://github.com/indygreg/python-zstandard/blob/0.22.0/setup_zstd.py#L38-L40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,16 @@ requirements:
     - m2-patch  # [win]
   host:
     - python
-    - cffi 1.16
+    - cffi 1.16  # [py<313]
+    - cffi 1.17  # [py>312]
     - pip
     - setuptools
     - wheel
     - zstd {{ zstd_version }}
   run:
     - python
-    - cffi >=1.11
+    - cffi >=1.11  # [py<313]
+    - cffi >=1.17  # [py>312]
     # The system zstd library and headers must match what python-zstandard is coded against exactly.
     # https://github.com/indygreg/python-zstandard/blob/0.22.0/zstd/zstd.h#L110
     # https://github.com/indygreg/python-zstandard/blob/0.22.0/setup_zstd.py#L38-L40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - cffi 1.16  # [py<313]
     - cffi 1.17  # [py>312]
     - pip
-    - setuptools
+    - setuptools <69.0.0 
     - wheel
     - zstd {{ zstd_version }}
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "zstandard" %}
-{% set version = "0.22.0" %}
-{% set zstd_version = "1.5.5" %}
+{% set version = "0.23.0" %}
+{% set zstd_version = "1.5.6" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70
+  sha256: b2d8c62d08e7255f68f7a740bae85b3c9b8e5466baa9cbf7f57f1cde0ac6bc09
   patches:
     - use_system_zstd.patch
 


### PR DESCRIPTION
zstandard v0.23.0

**Destination channel:**  defaults

### Links

- [PKG-5314](https://anaconda.atlassian.net/browse/PKG-5314?atlOrigin=eyJpIjoiM2U2MTQ5ZGZlYjNjNGM2YmE5ZTY1YWQ0MzNhMGYzZDQiLCJwIjoiaiJ9) 
- [Upstream repository](https://github.com/indygreg/python-zstandard/tree/0.23.0)
- [Upstream changelog/diff]()
- [pypoject.toml](https://github.com/indygreg/python-zstandard/blob/0.23.0/pyproject.toml)

### Explanation of changes:

- Bump version and SHA
- Update `cffi` pinnings [build](https://github.com/indygreg/python-zstandard/blob/0.23.0/pyproject.toml#L3-L4) [run](https://github.com/indygreg/python-zstandard/blob/0.23.0/setup.py#L30-L34)
- Update `setuptools `pinning [link](https://github.com/indygreg/python-zstandard/blob/0.23.0/pyproject.toml#L5-L9)


[PKG-5314]: https://anaconda.atlassian.net/browse/PKG-5314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ